### PR TITLE
Support for undirected segments.

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,9 @@ These are the supported vector properties:
   Defaults to `false`.
 * `style`: Custom style properties. Supports all `JSXGraph.Line`
   options, for example `pointSize`, `width`, `color`.
+* `type`: Supported values are `"vector"` (default) and
+  `"segment"`. When set to `"segment"`, the vector is drawn without
+  the arrow.
 
 #### points
 
@@ -99,8 +102,23 @@ ignored when grading. These are the supported properties:
   interested in one of the coordinates, but not both.
 * `tip_x`, `tip_y`: Use these instead of `tip` when you are only
   interested in one of the coordinates, but not both.
+* `coords`: Combines `tail`, `tip`, `tail_x`, and `tail_y` as a single
+  rule. The `'_'` character represents a coordinate with any value.
+  Examples:
+  * `[[1, 1], [2, 2]]` - same as a combination of `tail: `[1, 1]` and
+    `tip: [2, 2]`.
+  * `[['_', 3], [5, '_']]` - same as a combination of `tail_y: 3` and
+    `tip_x: 5`.
 * `length`: The expected length of the vector.
 * `angle`: The expected vector angle.
+* `segment_coords`: Just like `coords`, except that it is intented to
+  be used with segments rather than vectors. Segments are not directed
+  and there's no distinction between `tail` and `tip` points.  -
+  `segment_coords: [[1, 2], [3, 4]]` is therefore equivalent to
+  `segment_coords: [[3, 4], [1, 2]]`.
+* `segment_angle`: Just like `angle`, but intended to be used with
+  segments. Segments are not directed and `segment_angle: 0` is
+  therefore equivalent to `segment_angle: 180`.
 
 Every property is optional - you can check an arbitray list of
 properties for each vector.

--- a/api-example.html
+++ b/api-example.html
@@ -39,7 +39,10 @@
                  'N': {angle: 90, angle_tolerance: 2, tail: [0, -0.75], tail_tolerance: 0.25},
                  'g': {angle: 270, angle_tolerance: 2, tail: [0, -0.75], tail_tolerance: 0.25},
                  'f': {angle: 180, angle_tolerance: 2, tail: [0, -0.75], tail_tolerance: 0.25}
-              }
+              },
+              custom_checks: [
+                  {check: 'compare_normal_and_gravity_lengths'}
+              ]
           };
         </script>
 

--- a/api-example.xml
+++ b/api-example.xml
@@ -24,20 +24,8 @@ import json
 import math
 
 
-try:
-    custom_checks
-except NameError:
-    custom_checks = {}
-try:
-    success_message
-except NameError:
-    success_message = 'Good job!'
-
-
 def vglcfn(e, ans):
     """Main grading function."""
-    global custom_checks
-    global success_message
     answer = json.loads(json.loads(ans)['answer'])
     grader = Grader(answer, custom_checks, success_message)
     return grader.grade()
@@ -90,38 +78,33 @@ def check_tip_y(check, vectors):
     if _check_coordinate(check, vec.tip.y):
         return 'Vector {} does not end at correct point.'.format(vec.name)
 
-def _check_coords(vec, expected, tolerance):
+def _coord_delta(expected, actual):
+    if expected == '_':
+        return 0
+    else:
+        return expected - actual
+
+def _coords_within_tolerance(vec, expected, tolerance):
     for expected_coords, vec_coords in ([expected[0], vec.tail], [expected[1], vec.tip]):
-        if expected_coords[0] == '_':
-            if expected_coords[1] != '_':
-                # Only y given; not interested in x.
-                if abs(expected_coords[1] - vec_coords.y) > tolerance:
-                    return True
-        elif expected_coords[1] == '_':
-            # Only x given; not interested in y.
-            if abs(expected_coords[0] - vec_coords.x) > tolerance:
-                return True
-        else:
-            # Both coordinates given; check distance from expected point.
-            x = expected_coords[0] - vec_coords.x
-            y = expected_coords[1] - vec_coords.y
-            if math.hypot(x, y) > tolerance:
-                return True
-    return False
+        delta_x = _coord_delta(expected_coords[0], vec_coords.x)
+        delta_y = _coord_delta(expected_coords[1], vec_coords.y)
+        if math.hypot(delta_x, delta_y) > tolerance:
+            return False
+    return True
 
 def check_coords(check, vectors):
     vec = vectors[check['vector']]
     expected = check['expected']
     tolerance = check.get('tolerance', 1.0)
-    if _check_coords(vec, expected, tolerance):
+    if not _coords_within_tolerance(vec, expected, tolerance):
         return 'Vector {} coordinates are not correct.'.format(vec.name)
 
 def check_segment_coords(check, vectors):
     vec = vectors[check['vector']]
     expected = check['expected']
     tolerance = check.get('tolerance', 1.0)
-    if _check_coords(vec, expected, tolerance) and \
-            _check_coords(vec.opposite(), expected, tolerance):
+    if not (_coords_within_tolerance(vec, expected, tolerance) or
+            _coords_within_tolerance(vec.opposite(), expected, tolerance)):
         return 'Segment {} coordinates are not correct.'.format(vec.name)
 
 def check_length(check, vectors):
@@ -130,7 +113,7 @@ def check_length(check, vectors):
     if abs(vec.length - check['expected']) > tolerance:
         return 'The length of {} is incorrect. Your length: {:.1f}'.format(vec.name, vec.length)
 
-def _check_angle(vec, expected, tolerance):
+def _angle_within_tolerance(vec, expected, tolerance):
     # Calculate angle between vec and identity vector with expected angle
     # using the formula:
     # angle = acos((A . B) / len(A)*len(B))
@@ -138,13 +121,13 @@ def _check_angle(vec, expected, tolerance):
     y = vec.tip.y - vec.tail.y
     dot_product = x * math.cos(expected) + y * math.sin(expected)
     angle = math.degrees(math.acos(dot_product / vec.length))
-    return abs(angle) > tolerance
+    return abs(angle) <= tolerance
 
 def check_angle(check, vectors):
     vec = vectors[check['vector']]
     tolerance = check.get('tolerance', 2.0)
     expected = math.radians(check['expected'])
-    if _check_angle(vec, expected, tolerance):
+    if not _angle_within_tolerance(vec, expected, tolerance):
         return 'The angle of {} is incorrect. Your angle: {:.1f}'.format(vec.name, vec.angle)
 
 def check_segment_angle(check, vectors):
@@ -153,9 +136,9 @@ def check_segment_angle(check, vectors):
     vec = vectors[check['vector']]
     tolerance = check.get('tolerance', 2.0)
     expected = math.radians(check['expected'])
-    if _check_angle(vec, expected, tolerance):
-        if _check_angle(vec.opposite(), expected, tolerance):
-            return 'The angle of {} is incorrect. Your angle: {:.1f}'.format(vec.name, vec.angle)
+    if not (_angle_within_tolerance(vec, expected, tolerance) or
+            _angle_within_tolerance(vec.opposite(), expected, tolerance)):
+        return 'The angle of {} is incorrect. Your angle: {:.1f}'.format(vec.name, vec.angle)
 
 
 class Point(object):
@@ -214,6 +197,7 @@ class Grader(object):
             tip = props['tip']
             vectors[name] = Vector(name, tail[0], tail[1], tip[0], tip[1])
         return vectors
+
 ]]>
 </script>
 <p>

--- a/api-example.xml
+++ b/api-example.xml
@@ -1,149 +1,219 @@
 <problem display_name="webGLDemo">
 <script type="loncapa/python">
 <![CDATA[
+### Custom Checks ###
+
+def check_compare_normal_and_gravity_lengths(check, vectors):
+    normal = vectors['N']
+    gravity = vectors['g']
+    if abs(normal.length - gravity.length) > 1.0:
+        return 'Normal Force and Gravitational Force should be similar lengths.'
+
+custom_checks = {
+  'compare_normal_and_gravity_lengths': check_compare_normal_and_gravity_lengths
+}
+
+success_message = 'Good job!'
+
+
+#################################################
+### Python API - Do not edit after this line ####
+#################################################
+
 import json
+import math
+
+
+try:
+    custom_checks
+except NameError:
+    custom_checks = {}
+try:
+    success_message
+except NameError:
+    success_message = 'Good job!'
+
+
 def vglcfn(e, ans):
-  '''
-  Grading a force diagram.
-  '''
-
-  ### Custom Checks ###
-
-  def check_compare_normal_and_gravity_lengths(vectors, points):
-      normal = vectors['N']
-      gravity = vectors['g']
-      if abs(normal.length - gravity.length) < 1.0:
-          return 'Normal Force and Gravitational Force should be similar lengths.'
-
-  custom_checks = {
-    'compare_normal_and_gravity_lengths': check_compare_normal_and_gravity_lengths
-  }
-  success_message = 'Good job!'
+    """Main grading function."""
+    global custom_checks
+    global success_message
+    answer = json.loads(json.loads(ans)['answer'])
+    grader = Grader(answer, custom_checks, success_message)
+    return grader.grade()
 
 
-  ### Python API - Do not edit after this line ####
+## Built-in check functions
+
+def check_presence(check, vectors):
+    if check['vector'] not in vectors:
+        return 'You need to use the {} vector.'.format(check['vector'])
+
+def check_tail(check, vectors):
+    vec = vectors[check['vector']]
+    tolerance = check.get('tolerance', 1.0)
+    expected = check['expected']
+    dist = math.hypot(expected[0] - vec.tail.x, expected[1] - vec.tail.y)
+    if dist > tolerance:
+        return 'Vector {} does not start at correct point.'.format(vec.name)
+
+def check_tip(check, vectors):
+    vec = vectors[check['vector']]
+    tolerance = check.get('tolerance', 1.0)
+    expected = check['expected']
+    dist = math.hypot(expected[0] - vec.tip.x, expected[1] - vec.tip.y)
+    if dist > tolerance:
+        return 'Vector {} does not end at correct point.'.format(vec.name)
+
+def _check_coordinate(check, coord):
+    tolerance = check.get('tolerance', 1.0)
+    expected = check['expected']
+    return abs(expected - coord) > tolerance
+
+def check_tail_x(check, vectors):
+    vec = vectors[check['vector']]
+    if _check_coordinate(check, vec.tail.x):
+        return 'Vector {} does not start at correct point.'.format(vec.name)
+
+def check_tail_y(check, vectors):
+    vec = vectors[check['vector']]
+    if _check_coordinate(check, vec.tail.y):
+        return 'Vector {} does not start at correct point.'.format(vec.name)
+
+def check_tip_x(check, vectors):
+    vec = vectors[check['vector']]
+    if _check_coordinate(check, vec.tip.x):
+        return 'Vector {} does not end at correct point.'.format(vec.name)
+
+def check_tip_y(check, vectors):
+    vec = vectors[check['vector']]
+    if _check_coordinate(check, vec.tip.y):
+        return 'Vector {} does not end at correct point.'.format(vec.name)
+
+def _check_coords(vec, expected, tolerance):
+    for expected_coords, vec_coords in ([expected[0], vec.tail], [expected[1], vec.tip]):
+        if expected_coords[0] == '_':
+            if expected_coords[1] != '_':
+                # Only y given; not interested in x.
+                if abs(expected_coords[1] - vec_coords.y) > tolerance:
+                    return True
+        elif expected_coords[1] == '_':
+            # Only x given; not interested in y.
+            if abs(expected_coords[0] - vec_coords.x) > tolerance:
+                return True
+        else:
+            # Both coordinates given; check distance from expected point.
+            x = expected_coords[0] - vec_coords.x
+            y = expected_coords[1] - vec_coords.y
+            if math.hypot(x, y) > tolerance:
+                return True
+    return False
+
+def check_coords(check, vectors):
+    vec = vectors[check['vector']]
+    expected = check['expected']
+    tolerance = check.get('tolerance', 1.0)
+    if _check_coords(vec, expected, tolerance):
+        return 'Vector {} coordinates are not correct.'.format(vec.name)
+
+def check_segment_coords(check, vectors):
+    vec = vectors[check['vector']]
+    expected = check['expected']
+    tolerance = check.get('tolerance', 1.0)
+    if _check_coords(vec, expected, tolerance) and \
+            _check_coords(vec.opposite(), expected, tolerance):
+        return 'Segment {} coordinates are not correct.'.format(vec.name)
+
+def check_length(check, vectors):
+    vec = vectors[check['vector']]
+    tolerance = check.get('tolerance', 1.0)
+    if abs(vec.length - check['expected']) > tolerance:
+        return 'The length of {} is incorrect. Your length: {:.1f}'.format(vec.name, vec.length)
+
+def _check_angle(vec, expected, tolerance):
+    # Calculate angle between vec and identity vector with expected angle
+    # using the formula:
+    # angle = acos((A . B) / len(A)*len(B))
+    x = vec.tip.x - vec.tail.x
+    y = vec.tip.y - vec.tail.y
+    dot_product = x * math.cos(expected) + y * math.sin(expected)
+    angle = math.degrees(math.acos(dot_product / vec.length))
+    return abs(angle) > tolerance
+
+def check_angle(check, vectors):
+    vec = vectors[check['vector']]
+    tolerance = check.get('tolerance', 2.0)
+    expected = math.radians(check['expected'])
+    if _check_angle(vec, expected, tolerance):
+        return 'The angle of {} is incorrect. Your angle: {:.1f}'.format(vec.name, vec.angle)
+
+def check_segment_angle(check, vectors):
+    # Segments are not directed, so we must check the angle between the segment and
+    # the vector that represents it, as well as its opposite vector.
+    vec = vectors[check['vector']]
+    tolerance = check.get('tolerance', 2.0)
+    expected = math.radians(check['expected'])
+    if _check_angle(vec, expected, tolerance):
+        if _check_angle(vec.opposite(), expected, tolerance):
+            return 'The angle of {} is incorrect. Your angle: {:.1f}'.format(vec.name, vec.angle)
 
 
-  ## Built-in check functions
+class Point(object):
+    def __init__(self, x, y):
+        self.x = x
+        self.y = y
 
-  def check_presence(check, vectors):
-      if check['vector'] not in vectors:
-          return 'You need to use the {} vector.'.format(check['vector'])
+class Vector(object):
+    def __init__(self, name, x1, y1, x2, y2):
+        self.name = name
+        self.tail = Point(x1, y1)
+        self.tip = Point(x2, y2)
+        self.length = math.hypot(x2 - x1, y2 - y1)
+        angle = math.degrees(math.atan2(y2 - y1, x2 - x1))
+        if angle < 0:
+            angle += 360
+        self.angle = angle
 
-  def check_tail(check, vectors):
-      vec = vectors[check['vector']]
-      tolerance = check.get('tolerance', 1.0)
-      expected = check['expected']
-      dist = math.hypot(expected[0] - vec.tail.x, expected[1] - vec.tail.y)
-      if dist > tolerance:
-          return 'Vector {} does not start at correct point.'.format(vec.name)
+    def opposite(self):
+        return Vector(self.name, -self.tail.x, -self.tail.y, -self.tip.x, -self.tip.y)
 
-  def check_tip(check, vectors):
-      vec = vectors[check['vector']]
-      tolerance = check.get('tolerance', 1.0)
-      expected = check['expected']
-      dist = math.hypot(expected[0] - vec.tip.x, expected[1] - vec.tip.y)
-      if dist > tolerance:
-          return 'Vector {} does not end at correct point.'.format(vec.name)
+class Grader(object):
+    check_registry = {
+        'presence': check_presence,
+        'tail': check_tail,
+        'tip': check_tip,
+        'tail_x': check_tail_x,
+        'tail_y': check_tail_y,
+        'tip_x': check_tip_x,
+        'tip_y': check_tip_y,
+        'coords': check_coords,
+        'length': check_length,
+        'angle': check_angle,
+        'segment_angle': check_segment_angle,
+        'segment_coords': check_segment_coords,
+    }
 
-  def _check_coordinate(check, coord):
-      tolerance = check.get('tolerance', 1.0)
-      expected = check['expected']
-      return abs(expected - coord) > tolerance
+    def __init__(self, answer, custom_checks, success_message='Test passed'):
+        self.answer = answer
+        self.check_registry.update(custom_checks)
+        self.success_message = success_message
 
-  def check_tail_x(check, vectors):
-      vec = vectors[check['vector']]
-      if _check_coordinate(check, vec.tail.x):
-          return 'Vector {} does not start at correct point.'.format(vec.name)
+    def grade(self):
+        for check in self.answer['checks']:
+            check_fn = self.check_registry[check['check']]
+            result = check_fn(check, self._get_vectors())
+            if result:
+                return {'ok': False, 'msg': result}
 
-  def check_tail_y(check, vectors):
-      vec = vectors[check['vector']]
-      if _check_coordinate(check, vec.tail.y):
-          return 'Vector {} does not start at correct point.'.format(vec.name)
+        return {'ok': True, 'msg': self.success_message}
 
-  def check_tip_x(check, vectors):
-      vec = vectors[check['vector']]
-      if _check_coordinate(check, vec.tip.x):
-          return 'Vector {} does not end at correct point.'.format(vec.name)
-
-  def check_tip_y(check, vectors):
-      vec = vectors[check['vector']]
-      if _check_coordinate(check, vec.tip.y):
-          return 'Vector {} does not tip at correct point.'.format(vec.name)
-
-  def check_length(check, vectors):
-      vec = vectors[check['vector']]
-      tolerance = check.get('tolerance', 1.0)
-      if abs(vec.length - check['expected']) > tolerance:
-          return 'The length of {} is incorrect. Your length: {:.1f}'.format(vec.name, vec.length)
-
-  def check_angle(check, vectors):
-      vec = vectors[check['vector']]
-      tolerance = check.get('tolerance', 2.0)
-      expected = math.radians(check['expected'])
-      x = vec.tip.x - vec.tail.x
-      y = vec.tip.y - vec.tail.y
-      dot_product = x * math.cos(expected) + y * math.sin(expected)
-      angle = math.degrees(math.acos(dot_product / vec.length))
-      if abs(angle) > tolerance:
-          return 'The angle of {} is incorrect. Your angle: {:.1f}'.format(vec.name, vec.angle)
-
-
-  class Point(object):
-      def __init__(self, x, y):
-          self.x = x
-          self.y = y
-
-  class Vector(object):
-      def __init__(self, name, x1, y1, x2, y2):
-          self.name = name
-          self.tail = Point(x1, y1)
-          self.tip = Point(x2, y2)
-          self.length = math.hypot(x2 - x1, y2 - y1)
-          angle = math.degrees(math.atan2(y2 - y1, x2 - x1))
-          if angle < 0:
-              angle += 360
-          self.angle = angle
-
-  class Grader(object):
-      check_registry = {
-          'presence': check_presence,
-          'tail': check_tail,
-          'tip': check_tip,
-          'tail_x': check_tail_x,
-          'tail_y': check_tail_y,
-          'tip_x': check_tip_x,
-          'tip_y': check_tip_y,
-          'length': check_length,
-          'angle': check_angle,
-      }
-
-      def __init__(self, answer, custom_checks, success_message='Test passed'):
-          self.answer = answer
-          self.check_registry.update(custom_checks)
-          self.success_message = success_message
-
-      def grade(self):
-          for check in self.answer['checks']:
-              check_fn = self.check_registry[check['check']]
-              result = check_fn(check, self._get_vectors())
-              if result:
-                  return {'ok': False, 'msg': result}
-
-          return {'ok': True, 'msg': self.success_message}
-
-      def _get_vectors(self):
-          vectors = {}
-          for name, props in self.answer['vectors'].iteritems():
-              tail = props['tail']
-              tip = props['tip']
-              vectors[name] = Vector(name, tail[0], tail[1], tip[0], tip[1])
-          return vectors
-
-  answer = json.loads(json.loads(ans)['answer'])
-  grader = Grader(answer, custom_checks, success_message)
-
-  return grader.grade()
+    def _get_vectors(self):
+        vectors = {}
+        for name, props in self.answer['vectors'].iteritems():
+            tail = props['tail']
+            tip = props['tip']
+            vectors[name] = Vector(name, tail[0], tail[1], tip[0], tip[1])
+        return vectors
 ]]>
 </script>
 <p>

--- a/test_vectordraw.py
+++ b/test_vectordraw.py
@@ -1,0 +1,146 @@
+import unittest
+import vectordraw as vd
+
+
+class VectorDrawTest(unittest.TestCase):
+
+    def __init__(self, *args, **kwargs):
+        super(VectorDrawTest, self).__init__(*args, **kwargs)
+        # Alias assertions to make tests read better.
+        self.assertPasses = self.assertIsNone
+        self.assertFails = self.assertEquals
+
+    # Helpers
+
+    def check(self, expected=None, tolerance=1.0, vector='vec'):
+        return {'vector': vector, 'expected': expected, 'tolerance': tolerance}
+
+    def vector(self, x1=0, y1=0, x2=1, y2=1, name='vec'):
+        return vd.Vector(name, x1, y1, x2, y2)
+
+    # Test built-in checks
+
+    def test_check_presence(self):
+        errmsg = 'You need to use the othervec vector.'
+        vectors = {'myvec': self.vector(name='myvec')}
+        self.assertPasses(vd.check_presence(self.check(vector='myvec'), vectors))
+        self.assertFails(vd.check_presence(self.check(vector='othervec'), vectors), errmsg)
+
+    def test_check_tail(self):
+        errmsg = 'Vector vec does not start at correct point.'
+        vectors = {'vec': self.vector(3, 3, 4, 4)}
+        self.assertPasses(vd.check_tail(self.check([3, 3], 0), vectors))
+        self.assertPasses(vd.check_tail(self.check([4, 4], 1.5), vectors))
+        self.assertFails(vd.check_tail(self.check([3.1, 3], 0), vectors), errmsg)
+        self.assertFails(vd.check_tail(self.check([4, 4], 1.0), vectors), errmsg)
+
+    def test_check_tip(self):
+        errmsg = 'Vector vec does not end at correct point.'
+        vectors = {'vec': self.vector(3, 3, 4, 4)}
+        self.assertPasses(vd.check_tip(self.check([4, 4], 0), vectors))
+        self.assertPasses(vd.check_tip(self.check([3, 3], 1.5), vectors))
+        self.assertFails(vd.check_tip(self.check([4.1, 4], 0), vectors), errmsg)
+        self.assertFails(vd.check_tip(self.check([3, 3], 1.0), vectors), errmsg)
+
+    def test_check_tail_x(self):
+        errmsg = 'Vector vec does not start at correct point.'
+        vectors = {'vec': self.vector(3, 12, 4, 40)}
+        self.assertPasses(vd.check_tail_x(self.check(3, 0), vectors))
+        self.assertPasses(vd.check_tail_x(self.check(4, 1), vectors))
+        self.assertFails(vd.check_tail_x(self.check(5, 0), vectors), errmsg)
+        self.assertFails(vd.check_tail_x(self.check(5, 1.5), vectors), errmsg)
+
+    def test_check_tail_y(self):
+        errmsg = 'Vector vec does not start at correct point.'
+        vectors = {'vec': self.vector(3, 12, 4, 40)}
+        self.assertPasses(vd.check_tail_y(self.check(12, 0), vectors))
+        self.assertPasses(vd.check_tail_y(self.check(13, 1), vectors))
+        self.assertFails(vd.check_tail_y(self.check(13, 0), vectors), errmsg)
+        self.assertFails(vd.check_tail_y(self.check(10, 1.5), vectors), errmsg)
+
+    def test_check_tip_x(self):
+        errmsg = 'Vector vec does not end at correct point.'
+        vectors = {'vec': self.vector(3, 12, 4, 40)}
+        self.assertPasses(vd.check_tip_x(self.check(4, 0), vectors))
+        self.assertPasses(vd.check_tip_x(self.check(5, 1), vectors))
+        self.assertFails(vd.check_tip_x(self.check(5, 0), vectors), errmsg)
+        self.assertFails(vd.check_tip_x(self.check(2, 1.5), vectors), errmsg)
+
+    def test_check_tip_y(self):
+        errmsg = 'Vector vec does not end at correct point.'
+        vectors = {'vec': self.vector(3, 12, 4, 40)}
+        self.assertPasses(vd.check_tip_y(self.check(40, 0), vectors))
+        self.assertPasses(vd.check_tip_y(self.check(33, 10), vectors))
+        self.assertFails(vd.check_tip_y(self.check(41, 0), vectors), errmsg)
+        self.assertFails(vd.check_tip_y(self.check(29, 10), vectors), errmsg)
+
+    def test_check_coords(self):
+        errmsg = 'Vector vec coordinates are not correct.'
+        vectors = {'vec': self.vector(1, 2, 3, 4)}
+        self.assertPasses(vd.check_coords(self.check([[1, 2], [3, 4]], 0), vectors))
+        self.assertPasses(vd.check_coords(self.check([[1, 3], [4, 4]], 2), vectors))
+        self.assertPasses(vd.check_coords(self.check([['_', 2], [3, '_']], 0), vectors))
+        self.assertPasses(vd.check_coords(self.check([[3, '_'], ['_', 5]], 2), vectors))
+        self.assertPasses(vd.check_coords(self.check([['_', '_'], ['_', 3]], 2), vectors))
+        self.assertPasses(vd.check_coords(self.check([['_', '_'], ['_', '_']], 0), vectors))
+        self.assertFails(vd.check_coords(self.check([[2, 1], [3, 4]], 0), vectors), errmsg)
+        self.assertFails(vd.check_coords(self.check([[3, 4], [1, 2]], 0), vectors), errmsg)
+        self.assertFails(vd.check_coords(self.check([[1, 2], [4, 3]], 1), vectors), errmsg)
+        self.assertFails(vd.check_coords(self.check([[-1, -2], [-3, -4]], 0), vectors), errmsg)
+        self.assertFails(vd.check_coords(self.check([['_', 5], [3, 4]], 1), vectors), errmsg)
+        self.assertFails(vd.check_coords(self.check([['_', 2], [1, '_']], 1), vectors), errmsg)
+        self.assertFails(vd.check_coords(self.check([[-2, '_'], ['_', -4]], 1), vectors), errmsg)
+        self.assertFails(vd.check_coords(self.check([['_', '_'], ['_', -4]], 1), vectors), errmsg)
+
+    def test_check_segment_coords(self):
+        errmsg = 'Segment vec coordinates are not correct.'
+        vectors = {'vec': self.vector(1, 2, 3, 4)}
+        self.assertPasses(vd.check_segment_coords(self.check([[1, 2], [3, 4]], 0), vectors))
+        self.assertPasses(vd.check_segment_coords(self.check([[1, 3], [4, 4]], 2), vectors))
+        self.assertPasses(vd.check_segment_coords(self.check([['_', 2], [3, '_']], 0), vectors))
+        self.assertPasses(vd.check_segment_coords(self.check([[3, '_'], ['_', 5]], 2), vectors))
+        self.assertPasses(vd.check_segment_coords(self.check([['_', '_'], ['_', 3]], 2), vectors))
+        self.assertPasses(vd.check_segment_coords(self.check([['_', '_'], ['_', '_']], 0), vectors))
+        self.assertPasses(vd.check_segment_coords(self.check([[-1, -2], [-3, -4]], 0), vectors))
+        self.assertPasses(vd.check_segment_coords(self.check([['_', '_'], ['_', -4]], 1), vectors))
+        self.assertPasses(vd.check_segment_coords(self.check([[-2, '_'], ['_', -4]], 1), vectors))
+        self.assertFails(vd.check_segment_coords(self.check([[2, 1], [3, 4]], 0), vectors), errmsg)
+        self.assertFails(vd.check_segment_coords(self.check([[3, 4], [1, 2]], 0), vectors), errmsg)
+        self.assertFails(vd.check_segment_coords(self.check([[1, 2], [4, 3]], 1), vectors), errmsg)
+        self.assertFails(vd.check_segment_coords(self.check([['_', 5], [3, 4]], 1), vectors), errmsg)
+        self.assertFails(vd.check_segment_coords(self.check([['_', 2], [1, '_']], 1), vectors), errmsg)
+        self.assertFails(vd.check_segment_coords(self.check([['_', '_'], ['_', 5.5]], 1), vectors), errmsg)
+
+    def test_check_length(self):
+        errmsg = 'The length of vec is incorrect. Your length: 5.0'
+        vectors = {'vec': self.vector(0, 0, 3, 4)}
+        self.assertPasses(vd.check_length(self.check(5, 0), vectors))
+        self.assertPasses(vd.check_length(self.check(7, 2.5), vectors))
+        self.assertFails(vd.check_length(self.check(4.5, 0), vectors), errmsg)
+        self.assertFails(vd.check_length(self.check(5.5, 0.25), vectors), errmsg)
+
+    def test_check_angle(self):
+        errmsg = 'The angle of vec is incorrect. Your angle: 45.0'
+        vectors = {'vec': self.vector(0, 0, 5, 5)}
+        self.assertPasses(vd.check_angle(self.check(45, 0), vectors))
+        self.assertPasses(vd.check_angle(self.check(-315, 0), vectors))
+        self.assertPasses(vd.check_angle(self.check(405, 0), vectors))
+        self.assertPasses(vd.check_angle(self.check(-5, 55), vectors))
+        self.assertPasses(vd.check_angle(self.check(42, 5), vectors))
+        self.assertFails(vd.check_angle(self.check(315, 0), vectors), errmsg)
+        self.assertFails(vd.check_angle(self.check(30, 9), vectors), errmsg)
+
+    def test_check_segment_angle(self):
+        errmsg = 'The angle of vec is incorrect. Your angle: 45.0'
+        vectors = {'vec': self.vector(0, 0, 5, 5)}
+        self.assertPasses(vd.check_segment_angle(self.check(45, 0), vectors))
+        self.assertPasses(vd.check_segment_angle(self.check(-315, 0), vectors))
+        self.assertPasses(vd.check_segment_angle(self.check(405, 0), vectors))
+        self.assertPasses(vd.check_segment_angle(self.check(42, 5), vectors))
+        self.assertFails(vd.check_segment_angle(self.check(-405, 0), vectors), errmsg)
+        self.assertFails(vd.check_segment_angle(self.check(315, 0), vectors), errmsg)
+        self.assertFails(vd.check_segment_angle(self.check(-45, 9), vectors), errmsg)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/vectordraw.js
+++ b/vectordraw.js
@@ -186,7 +186,9 @@ VectorDraw.prototype.renderVector = function(idx, coords) {
         withLabel: true,
         showInfoBox: false
     });
-    var arrow = this.board.create('arrow', [tail, tip], {
+
+    var line_type = vec.type === 'segment' ? 'segment' : 'arrow';
+    var line = this.board.create(line_type, [tail, tip], {
         name: vec.name,
         strokeWidth: style.width,
         strokeColor: style.color
@@ -198,7 +200,7 @@ VectorDraw.prototype.renderVector = function(idx, coords) {
     var option = this.element.find('.menu option[value=' + idx + ']');
     option.prop('disabled', true).prop('selected', false);
 
-    return arrow;
+    return line;
 };
 
 VectorDraw.prototype.removeVector = function(idx) {
@@ -404,8 +406,8 @@ var getInput = function() {
 
     _.each(vectordraw.settings.expected_result, function(answer, name) {
         checks.push({vector: name, check: 'presence'});
-        ['tail', 'tail_x', 'tail_y', 'tip', 'tip_x', 'tip_y',
-         'length', 'angle'].forEach(function(prop) {
+        ['tail', 'tail_x', 'tail_y', 'tip', 'tip_x', 'tip_y', 'coords',
+         'length', 'angle', 'segment_angle', 'segment_coords'].forEach(function(prop) {
             if (prop in answer) {
                 var check = {vector: name, check: prop, expected: answer[prop]};
                 if (prop + '_tolerance' in answer) {

--- a/vectordraw.py
+++ b/vectordraw.py
@@ -2,6 +2,24 @@
 # script tag of the problem XML definition - see api-example.xml for
 # an example.
 
+import json
+import math
+
+def vglcfn(e, ans):
+    """Main grading function."""
+    try:
+        custom_checks
+    except NameError:
+        custom_checks = {}
+    try:
+        success_message
+    except NameError:
+        success_message = 'Good job!'
+
+    answer = json.loads(json.loads(ans)['answer'])
+    grader = Grader(answer, custom_checks, success_message)
+    return grader.grade()
+
 
 ## Built-in check functions
 
@@ -48,7 +66,41 @@ def check_tip_x(check, vectors):
 def check_tip_y(check, vectors):
     vec = vectors[check['vector']]
     if _check_coordinate(check, vec.tip.y):
-        return 'Vector {} does not tip at correct point.'.format(vec.name)
+        return 'Vector {} does not end at correct point.'.format(vec.name)
+
+def _check_coords(vec, expected, tolerance):
+    for expected_coords, vec_coords in ([expected[0], vec.tail], [expected[1], vec.tip]):
+        if expected_coords[0] == '_':
+            if expected_coords[1] != '_':
+                # Only y given; not interested in x.
+                if abs(expected_coords[1] - vec_coords.y) > tolerance:
+                    return True
+        elif expected_coords[1] == '_':
+            # Only x given; not interested in y.
+            if abs(expected_coords[0] - vec_coords.x) > tolerance:
+                return True
+        else:
+            # Both coordinates given; check distance from expected point.
+            x = expected_coords[0] - vec_coords.x
+            y = expected_coords[1] - vec_coords.y
+            if math.hypot(x, y) > tolerance:
+                return True
+    return False
+
+def check_coords(check, vectors):
+    vec = vectors[check['vector']]
+    expected = check['expected']
+    tolerance = check.get('tolerance', 1.0)
+    if _check_coords(vec, expected, tolerance):
+        return 'Vector {} coordinates are not correct.'.format(vec.name)
+
+def check_segment_coords(check, vectors):
+    vec = vectors[check['vector']]
+    expected = check['expected']
+    tolerance = check.get('tolerance', 1.0)
+    if _check_coords(vec, expected, tolerance) and \
+            _check_coords(vec.opposite(), expected, tolerance):
+        return 'Segment {} coordinates are not correct.'.format(vec.name)
 
 def check_length(check, vectors):
     vec = vectors[check['vector']]
@@ -56,10 +108,7 @@ def check_length(check, vectors):
     if abs(vec.length - check['expected']) > tolerance:
         return 'The length of {} is incorrect. Your length: {:.1f}'.format(vec.name, vec.length)
 
-def check_angle(check, vectors):
-    vec = vectors[check['vector']]
-    tolerance = check.get('tolerance', 2.0)
-    expected = math.radians(check['expected'])
+def _check_angle(vec, expected, tolerance):
     # Calculate angle between vec and identity vector with expected angle
     # using the formula:
     # angle = acos((A . B) / len(A)*len(B))
@@ -67,8 +116,24 @@ def check_angle(check, vectors):
     y = vec.tip.y - vec.tail.y
     dot_product = x * math.cos(expected) + y * math.sin(expected)
     angle = math.degrees(math.acos(dot_product / vec.length))
-    if abs(angle) > tolerance:
+    return abs(angle) > tolerance
+
+def check_angle(check, vectors):
+    vec = vectors[check['vector']]
+    tolerance = check.get('tolerance', 2.0)
+    expected = math.radians(check['expected'])
+    if _check_angle(vec, expected, tolerance):
         return 'The angle of {} is incorrect. Your angle: {:.1f}'.format(vec.name, vec.angle)
+
+def check_segment_angle(check, vectors):
+    # Segments are not directed, so we must check the angle between the segment and
+    # the vector that represents it, as well as its opposite vector.
+    vec = vectors[check['vector']]
+    tolerance = check.get('tolerance', 2.0)
+    expected = math.radians(check['expected'])
+    if _check_angle(vec, expected, tolerance):
+        if _check_angle(vec.opposite(), expected, tolerance):
+            return 'The angle of {} is incorrect. Your angle: {:.1f}'.format(vec.name, vec.angle)
 
 
 class Point(object):
@@ -87,6 +152,9 @@ class Vector(object):
             angle += 360
         self.angle = angle
 
+    def opposite(self):
+        return Vector(self.name, -self.tail.x, -self.tail.y, -self.tip.x, -self.tip.y)
+
 class Grader(object):
     check_registry = {
         'presence': check_presence,
@@ -96,8 +164,11 @@ class Grader(object):
         'tail_y': check_tail_y,
         'tip_x': check_tip_x,
         'tip_y': check_tip_y,
+        'coords': check_coords,
         'length': check_length,
         'angle': check_angle,
+        'segment_angle': check_segment_angle,
+        'segment_coords': check_segment_coords,
     }
 
     def __init__(self, answer, custom_checks, success_message='Test passed'):
@@ -121,8 +192,3 @@ class Grader(object):
             tip = props['tip']
             vectors[name] = Vector(name, tail[0], tail[1], tip[0], tip[1])
         return vectors
-
-answer = json.loads(json.loads(ans)['answer'])
-grader = Grader(answer, custom_checks, success_message)
-
-return grader.grade()

--- a/vectordraw.py
+++ b/vectordraw.py
@@ -2,24 +2,24 @@
 # script tag of the problem XML definition - see api-example.xml for
 # an example.
 
+
+# If you need custom checks, define them here.
+custom_checks = {}
+
+# The message shown to the student when all checks are successful.
+success_message = 'Good job!'
+
+
+#################################################
+### Python API - Do not edit after this line ####
+#################################################
+
 import json
 import math
 
 
-try:
-    custom_checks
-except NameError:
-    custom_checks = {}
-try:
-    success_message
-except NameError:
-    success_message = 'Good job!'
-
-
 def vglcfn(e, ans):
     """Main grading function."""
-    global custom_checks
-    global success_message
     answer = json.loads(json.loads(ans)['answer'])
     grader = Grader(answer, custom_checks, success_message)
     return grader.grade()
@@ -72,38 +72,33 @@ def check_tip_y(check, vectors):
     if _check_coordinate(check, vec.tip.y):
         return 'Vector {} does not end at correct point.'.format(vec.name)
 
-def _check_coords(vec, expected, tolerance):
+def _coord_delta(expected, actual):
+    if expected == '_':
+        return 0
+    else:
+        return expected - actual
+
+def _coords_within_tolerance(vec, expected, tolerance):
     for expected_coords, vec_coords in ([expected[0], vec.tail], [expected[1], vec.tip]):
-        if expected_coords[0] == '_':
-            if expected_coords[1] != '_':
-                # Only y given; not interested in x.
-                if abs(expected_coords[1] - vec_coords.y) > tolerance:
-                    return True
-        elif expected_coords[1] == '_':
-            # Only x given; not interested in y.
-            if abs(expected_coords[0] - vec_coords.x) > tolerance:
-                return True
-        else:
-            # Both coordinates given; check distance from expected point.
-            x = expected_coords[0] - vec_coords.x
-            y = expected_coords[1] - vec_coords.y
-            if math.hypot(x, y) > tolerance:
-                return True
-    return False
+        delta_x = _coord_delta(expected_coords[0], vec_coords.x)
+        delta_y = _coord_delta(expected_coords[1], vec_coords.y)
+        if math.hypot(delta_x, delta_y) > tolerance:
+            return False
+    return True
 
 def check_coords(check, vectors):
     vec = vectors[check['vector']]
     expected = check['expected']
     tolerance = check.get('tolerance', 1.0)
-    if _check_coords(vec, expected, tolerance):
+    if not _coords_within_tolerance(vec, expected, tolerance):
         return 'Vector {} coordinates are not correct.'.format(vec.name)
 
 def check_segment_coords(check, vectors):
     vec = vectors[check['vector']]
     expected = check['expected']
     tolerance = check.get('tolerance', 1.0)
-    if _check_coords(vec, expected, tolerance) and \
-            _check_coords(vec.opposite(), expected, tolerance):
+    if not (_coords_within_tolerance(vec, expected, tolerance) or
+            _coords_within_tolerance(vec.opposite(), expected, tolerance)):
         return 'Segment {} coordinates are not correct.'.format(vec.name)
 
 def check_length(check, vectors):
@@ -112,7 +107,7 @@ def check_length(check, vectors):
     if abs(vec.length - check['expected']) > tolerance:
         return 'The length of {} is incorrect. Your length: {:.1f}'.format(vec.name, vec.length)
 
-def _check_angle(vec, expected, tolerance):
+def _angle_within_tolerance(vec, expected, tolerance):
     # Calculate angle between vec and identity vector with expected angle
     # using the formula:
     # angle = acos((A . B) / len(A)*len(B))
@@ -120,13 +115,13 @@ def _check_angle(vec, expected, tolerance):
     y = vec.tip.y - vec.tail.y
     dot_product = x * math.cos(expected) + y * math.sin(expected)
     angle = math.degrees(math.acos(dot_product / vec.length))
-    return abs(angle) > tolerance
+    return abs(angle) <= tolerance
 
 def check_angle(check, vectors):
     vec = vectors[check['vector']]
     tolerance = check.get('tolerance', 2.0)
     expected = math.radians(check['expected'])
-    if _check_angle(vec, expected, tolerance):
+    if not _angle_within_tolerance(vec, expected, tolerance):
         return 'The angle of {} is incorrect. Your angle: {:.1f}'.format(vec.name, vec.angle)
 
 def check_segment_angle(check, vectors):
@@ -135,9 +130,9 @@ def check_segment_angle(check, vectors):
     vec = vectors[check['vector']]
     tolerance = check.get('tolerance', 2.0)
     expected = math.radians(check['expected'])
-    if _check_angle(vec, expected, tolerance):
-        if _check_angle(vec.opposite(), expected, tolerance):
-            return 'The angle of {} is incorrect. Your angle: {:.1f}'.format(vec.name, vec.angle)
+    if not (_angle_within_tolerance(vec, expected, tolerance) or
+            _angle_within_tolerance(vec.opposite(), expected, tolerance)):
+        return 'The angle of {} is incorrect. Your angle: {:.1f}'.format(vec.name, vec.angle)
 
 
 class Point(object):

--- a/vectordraw.py
+++ b/vectordraw.py
@@ -5,17 +5,21 @@
 import json
 import math
 
+
+try:
+    custom_checks
+except NameError:
+    custom_checks = {}
+try:
+    success_message
+except NameError:
+    success_message = 'Good job!'
+
+
 def vglcfn(e, ans):
     """Main grading function."""
-    try:
-        custom_checks
-    except NameError:
-        custom_checks = {}
-    try:
-        success_message
-    except NameError:
-        success_message = 'Good job!'
-
+    global custom_checks
+    global success_message
     answer = json.loads(json.loads(ans)['answer'])
     grader = Grader(answer, custom_checks, success_message)
     return grader.grade()


### PR DESCRIPTION
This patch adds some support for defining and grading segments.
Segments work just like vectors except that they are drawn without the arrow.

Segments are currently defined as special types of vectors. To define a segment,
use `type: "segment"` in the `vectors: [...]` definition.

Segments work with all the same checks as vectors. Two new types of checks
intended to be used specifically with segments have been added:

* `segment_angle` - it works just like `angle`, except that the segment can
  be drawn in either direction (`segment_angle: 0` is equivalent to
  `segment_angle: 180`, etc).
* `segment_coords`: This defines the expected coordinates of the segment
  ending points, for example: `[[1.5, 1.5], [3, 3]]`. Since segments aren't
  directed, `segment_coords: [[x1, y1], [x2, y2]]` is equivalent to
  `[[x2, y2], [x1, y1]]`.